### PR TITLE
Vectorizing compute Ainv.

### DIFF
--- a/py-rom-tools/pod/rbf_affine.py
+++ b/py-rom-tools/pod/rbf_affine.py
@@ -258,11 +258,7 @@ class RBFAffine:
   # -----------------------------------------------------------------------------------
   def action_A_inverse(self, rhs):
     u, s, vh = self.U, self.S, self.Vh
-    x = np.zeros(self.npoints+1)
-    for i in range(0,len(s)):
-      fac = np.dot(u[:,i],rhs) / s[i]
-      x = x + fac * vh[i,:]
-    return x
+    return (u.T @ rhs / s) @ vh
         
 
 

--- a/py-rom-tools/pod/rbf_affine.py
+++ b/py-rom-tools/pod/rbf_affine.py
@@ -258,7 +258,7 @@ class RBFAffine:
   # -----------------------------------------------------------------------------------
   def action_A_inverse(self, rhs):
     u, s, vh = self.U, self.S, self.Vh
-    return (u.T @ rhs / s) @ vh
+    return vh.T @ (u.T @ rhs / s)
         
 
 


### PR DESCRIPTION
Calling `pod.evaluate()` many times for different parameters was slow due to the `action_A_inverse` function. This function is now vectorized which is much faster and produces the same result.